### PR TITLE
feat(action): fix empty arn during de-registering for initial deployment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -110,29 +110,25 @@ runs:
         if [[ "$PRIMARY_DEPLOYMENT_DEFINITION_ARN" == "$LATEST_PRODUCTION_TASK_DEFINITION" ]]; then  
               # Do not deregister task definition for initial deployment
               if [ ! -z "$PREVIOUS_PRODUCTION_TASK_DEFINITION" ]; then   
-                echo "task-definition-production=$PREVIOUS_PRODUCTION_TASK_DEFINITION" >> $GITHUB_OUTPUT
-                echo "task-definition-local=${{ steps.deploy-local-task-definition.outputs.previous-task-definition-arn }}" >> $GITHUB_OUTPUT
+                echo "TASK_DEFINITION_PRODUCTION=$PREVIOUS_PRODUCTION_TASK_DEFINITION" >> $GITHUB_ENV
+                echo "TASK_DEFINITION_LOCAL=${{ steps.deploy-local-task-definition.outputs.previous-task-definition-arn }}" >> $GITHUB_ENV
                 echo "fail-pipeline=false" >> $GITHUB_OUTPUT
               fi
         else
-            echo "task-definition-production=$LATEST_PRODUCTION_TASK_DEFINITION" >> $GITHUB_OUTPUT
-            echo "task-definition-local=${{ steps.deploy-local-task-definition.outputs.latest-task-definition-arn }}" >> $GITHUB_OUTPUT
+            echo "TASK_DEFINITION_PRODUCTION=$LATEST_PRODUCTION_TASK_DEFINITION" >> $GITHUB_ENV
+            echo "TASK_DEFINITION_LOCAL=${{ steps.deploy-local-task-definition.outputs.latest-task-definition-arn }}" >> $GITHUB_ENV
             echo "fail-pipeline=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Deregister production task definition
-      if: ${{ always() && steps.deploy-production-task-definition.outcome == 'success' }}
+      if: ${{ always() && steps.deploy-production-task-definition.outcome == 'success' && env.TASK_DEFINITION_PRODUCTION != '' }}
       shell: bash
-      run: |
-        aws ecs deregister-task-definition \
-          --task-definition "${{ steps.determine-task-definitions-to-deregister.outputs.task-definition-production }}"
+      run: aws ecs deregister-task-definition --task-definition "$TASK_DEFINITION_PRODUCTION"
 
     - name: Deregister local task definition
-      if: ${{ always() && steps.deploy-local-task-definition.outcome == 'success' }}
+      if: ${{ always() && steps.deploy-local-task-definition.outcome == 'success' && env.TASK_DEFINITION_LOCAL != '' }}
       shell: bash
-      run: |
-        aws ecs deregister-task-definition \
-          --task-definition "${{ steps.determine-task-definitions-to-deregister.outputs.task-definition-local }}"
+      run: aws ecs deregister-task-definition --task-definition "$TASK_DEFINITION_LOCAL"
 
     - name: Fail pipeline
       if: ${{ always() && steps.determine-task-definitions-to-deregister.outputs.fail-pipeline == 'true'  }}

--- a/custom-deploy-steps/create-task-definition/action.yml
+++ b/custom-deploy-steps/create-task-definition/action.yml
@@ -101,5 +101,5 @@ runs:
       run: |
         aws ecs tag-resource \
           --resource-arn ${{ steps.deploy-task-definition.outputs.task-definition-arn }} \
-          --tags key=created_by,value=$DEPLOYMENT_TAG key=Name,value=$APPLICATION_ID \
+          --tags key=created_by,value="$DEPLOYMENT_TAG" key=Name,value="$APPLICATION_ID" \
           --region ${{ inputs.aws_region }}


### PR DESCRIPTION
Fix bug case of having an empty `arn` during de-registering for initial deployment 

example of failing CI
https://github.com/moneymeets/django-profile-api/actions/runs/8157425530/job/22297170613