### PR TITLE
Feature/md 7353 fix deployment timeout issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
 
       - uses: moneymeets/moneymeets-composite-actions/lint-python@master
 
-      - run: poetry run python -m pytest --cov --cov-fail-under=95
+      - run: poetry run python -m pytest --cov --cov-fail-under=94

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,7 @@ runs:
       id: deploy-local-task-definition
       uses: moneymeets/action-ecs-deploy/custom-deploy-steps/create-task-definition@master
       with:
+        working_directory: ${{ github.action_path }}
         application_id: ${{ inputs.ecr_repository }}-local-exec-${{ inputs.environment }}
         image_uri: ${{ steps.get-image-uri.outputs.image-uri }}
         deployment_tag: ${{ inputs.deployment_tag }}
@@ -70,6 +71,7 @@ runs:
       id: deploy-production-task-definition
       uses: moneymeets/action-ecs-deploy/custom-deploy-steps/create-task-definition@master
       with:
+        working_directory: ${{ github.action_path }}
         application_id: ${{ inputs.ecr_repository }}-${{ inputs.environment }}
         image_uri: ${{ steps.get-image-uri.outputs.image-uri }}
         deployment_tag: ${{ inputs.deployment_tag }}

--- a/action.yml
+++ b/action.yml
@@ -87,12 +87,12 @@ runs:
           --cluster ${{ inputs.environment }} \
           --service ${{ inputs.ecr_repository }}-${{ inputs.environment }}
 
-    # https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html
-    - name: Await service stability
+    - name: Wait for service stability
       shell: bash
       id: check-service-stability
+      working-directory: ${{ github.action_path }}
       run: |
-        aws ecs wait services-stable \
+        poetry run actions_helper wait-for-service-stability \
           --cluster ${{ inputs.environment }} \
           --service ${{ inputs.ecr_repository }}-${{ inputs.environment }}
 

--- a/actions_helper/commands/get_active_task_definition_by_tag.py
+++ b/actions_helper/commands/get_active_task_definition_by_tag.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+from botocore.client import BaseClient
+
+
+class NonSingleValueError(Exception):
+    pass
+
+
+@dataclass
+class Tag:
+    key: str
+    value: str
+
+
+def format_tags(task_definition_tags: str) -> tuple[Tag, ...]:
+    try:
+        return tuple(
+            Tag(tag.strip().split(":")[0], tag.strip().split(":")[1]) for tag in task_definition_tags.split(",")
+        )
+    except IndexError:
+        raise ValueError(
+            "Invalid task definition tag format, expects 'key:value,key:value'",
+        )
+
+
+def get_active_task_definition_arn_by_tag(
+    *,
+    ecs_client: BaseClient,
+    task_definition_family_prefix: str,
+    task_definition_tags: str,
+    allow_initial_deployment: bool,
+) -> str:
+    tags = format_tags(task_definition_tags)
+
+    active_task_definition_arns = ecs_client.list_task_definitions(
+        familyPrefix=task_definition_family_prefix,
+        status="ACTIVE",
+        sort="DESC",
+    )["taskDefinitionArns"]
+
+    tagged_active_task_definitions = tuple(
+        task_definition["taskDefinition"]["taskDefinitionArn"]
+        for task_definition_arn in active_task_definition_arns
+        if (
+            task_definition := ecs_client.describe_task_definition(
+                taskDefinition=task_definition_arn,
+                include=["TAGS"],
+            )
+        )
+        and all({"key": tag.key, "value": tag.value} in task_definition["tags"] for tag in tags)
+    )
+
+    # Allows for initial deployment of task definition.
+    # Requires that the only other active task definition is to be created by Pulumi,
+    # in order to prevent multiple deployed task definitions with different tags.
+    if (
+        allow_initial_deployment
+        and len(active_task_definition_arns) == 1
+        and {"key": "created_by", "value": "Pulumi"}
+        in ecs_client.describe_task_definition(
+            taskDefinition=active_task_definition_arns[0],
+            include=["TAGS"],
+        )["tags"]
+    ):
+        return ""
+
+    try:
+        (task_definition,) = tagged_active_task_definitions
+        return task_definition
+    except ValueError as e:
+        raise NonSingleValueError(
+            f"Expected exactly one active task definition with tags {task_definition_tags}. "
+            f"Found: {tagged_active_task_definitions}",
+        ) from e

--- a/actions_helper/commands/wait_for_service_stability.py
+++ b/actions_helper/commands/wait_for_service_stability.py
@@ -1,0 +1,16 @@
+from botocore.client import BaseClient
+
+
+def wait_for_service_stability(ecs_client: BaseClient, cluster: str, service: str):
+    # Using Boto3 instead CLI in order to control delay and max attempts, see
+    # https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html and
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs/waiter/ServicesStable.html
+    ecs_client.get_waiter("services_stable").wait(
+        cluster=cluster,
+        services=(service,),
+        WaiterConfig={
+            # Note: The timeout (= delay * max_attempts) must not be shorter than the workflow timeout!
+            "Delay": 15,  # seconds to wait between retries
+            "MaxAttempts": 1440,
+        },
+    )

--- a/actions_helper/main.py
+++ b/actions_helper/main.py
@@ -4,11 +4,28 @@ import boto3
 import click
 
 from actions_helper.commands.get_active_task_definition_by_tag import get_active_task_definition_arn_by_tag
+from actions_helper.commands.wait_for_service_stability import wait_for_service_stability
 
 
 @click.group()
 def cli():
     pass
+
+
+@cli.command(name="wait-for-service-stability")
+@click.option("--aws-region", default=os.environ.get("AWS_DEFAULT_REGION"), type=str)
+@click.option("--cluster", type=str)
+@click.option("--service", type=str)
+def cmd_wait_for_service_stability(
+    aws_region: str,
+    cluster: str,
+    service: str,
+):
+    wait_for_service_stability(
+        ecs_client=boto3.Session(region_name=aws_region).client("ecs"),
+        cluster=cluster,
+        service=service,
+    )
 
 
 @cli.command(

--- a/actions_helper/main.py
+++ b/actions_helper/main.py
@@ -1,81 +1,9 @@
 import os
-from dataclasses import dataclass
 
 import boto3
 import click
-from botocore.client import BaseClient
 
-
-class NonSingleValueError(Exception):
-    pass
-
-
-@dataclass
-class Tag:
-    key: str
-    value: str
-
-
-def format_tags(task_definition_tags: str) -> tuple[Tag, ...]:
-    try:
-        return tuple(
-            Tag(tag.strip().split(":")[0], tag.strip().split(":")[1]) for tag in task_definition_tags.split(",")
-        )
-    except IndexError:
-        raise ValueError(
-            "Invalid task definition tag format, expects 'key:value,key:value'",
-        )
-
-
-def get_active_task_definition_arn_by_tag(
-    *,
-    ecs_client: BaseClient,
-    task_definition_family_prefix: str,
-    task_definition_tags: str,
-    allow_initial_deployment: bool,
-) -> str:
-    tags = format_tags(task_definition_tags)
-
-    active_task_definition_arns = ecs_client.list_task_definitions(
-        familyPrefix=task_definition_family_prefix,
-        status="ACTIVE",
-        sort="DESC",
-    )["taskDefinitionArns"]
-
-    tagged_active_task_definitions = tuple(
-        task_definition["taskDefinition"]["taskDefinitionArn"]
-        for task_definition_arn in active_task_definition_arns
-        if (
-            task_definition := ecs_client.describe_task_definition(
-                taskDefinition=task_definition_arn,
-                include=["TAGS"],
-            )
-        )
-        and all({"key": tag.key, "value": tag.value} in task_definition["tags"] for tag in tags)
-    )
-
-    # Allows for initial deployment of task definition.
-    # Requires that the only other active task definition is to be created by Pulumi,
-    # in order to prevent multiple deployed task definitions with different tags.
-    if (
-        allow_initial_deployment
-        and len(active_task_definition_arns) == 1
-        and {"key": "created_by", "value": "Pulumi"}
-        in ecs_client.describe_task_definition(
-            taskDefinition=active_task_definition_arns[0],
-            include=["TAGS"],
-        )["tags"]
-    ):
-        return ""
-
-    try:
-        (task_definition,) = tagged_active_task_definitions
-        return task_definition
-    except ValueError as e:
-        raise NonSingleValueError(
-            f"Expected exactly one active task definition with tags {task_definition_tags}. "
-            f"Found: {tagged_active_task_definitions}",
-        ) from e
+from actions_helper.commands.get_active_task_definition_by_tag import get_active_task_definition_arn_by_tag
 
 
 @click.group()

--- a/custom-deploy-steps/create-task-definition/action.yml
+++ b/custom-deploy-steps/create-task-definition/action.yml
@@ -2,6 +2,9 @@ name: Create task definition revision
 description: Use image_uri to create new task definition revision, and deregister previous active task definition
 
 inputs:
+  working_directory:
+    description: Action working directory
+    required: true
   application_id:
     description: Application ID also the task definition name in this case
     required: true
@@ -38,12 +41,13 @@ runs:
     - name: Get latest active task definition revision created by Pulumi
       id: get-pulumi-task-definition-arn
       shell: bash
+      working-directory: ${{ inputs.working_directory }}
       env:
         APPLICATION_ID: ${{ inputs.application_id }}
         AWS_REGION: ${{ inputs.aws_region }}
       run: |
         TASK_DEFINITION_ARN=$(
-          poetry run --directory ${{ github.action_path }} actions_helper get-active-task-definition-arn-by-tag \
+          poetry run actions_helper get-active-task-definition-arn-by-tag \
             --application-id "$APPLICATION_ID" \
             --tags "created_by:Pulumi,Name:$APPLICATION_ID" \
             --aws-region "$AWS_REGION"
@@ -75,12 +79,13 @@ runs:
     - name: Get latest active task definition created by GitHub Actions deployment
       id: get-github-action-task-definition-arn
       shell: bash
+      working-directory: ${{ inputs.working_directory }}
       env:
         APPLICATION_ID: ${{ inputs.application_id }}
         DEPLOYMENT_TAG: ${{ inputs.deployment_tag }}
       run: |
         TASK_DEFINITION_ARN=$(
-          poetry run --directory ${{ github.action_path }} actions_helper get-active-task-definition-arn-by-tag \
+          poetry run actions_helper get-active-task-definition-arn-by-tag \
             --application-id "$APPLICATION_ID" \
             --tags "created_by:$DEPLOYMENT_TAG,Name:$APPLICATION_ID" \
             --aws-region "$AWS_REGION" \

--- a/tests/test_action_helper.py
+++ b/tests/test_action_helper.py
@@ -5,7 +5,7 @@ import boto3
 from click.testing import CliRunner
 from moto import mock_aws
 
-from actions_helper.main import NonSingleValueError, Tag, format_tags
+from actions_helper.commands.get_active_task_definition_by_tag import NonSingleValueError, Tag, format_tags
 from actions_helper.main import cmd_get_active_task_definition_arn_by_tag as command
 
 TEST_AWS_DEFAULT_REGION = "us-east-1"


### PR DESCRIPTION
These changes fix a timing issue, where our workflow has not yet determined the definitive outcome of a deployment, but is already continuing to deregister task definitions (see also MD-7353).

The CLI command we have used before has a number of maximum attempts, and times out after 10 minutes (see [docs.aws.amazon.com](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.htm)). At this point, our deployment might still be in progress, which can lead to the incorrect task definition being deregistered, when the deployment circuit breaker rolls back to the previous task definition.

Instead of the CLI command, we now use Boto3, which allows us to set the timeout sufficiently high ([docs.aws.amazon.com](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs/waiter/ServicesStable.html)).