### PR TITLE
feat(action): bump version to fix warning

### DIFF
--- a/custom-deploy-steps/create-task-definition/action.yml
+++ b/custom-deploy-steps/create-task-definition/action.yml
@@ -93,7 +93,7 @@ runs:
         )
         echo "previous-task-definition-arn=${TASK_DEFINITION_ARN}" >> $GITHUB_OUTPUT
 
-    - uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    - uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       id: deploy-task-definition
       with:
         task-definition: task-definition.json


### PR DESCRIPTION
There is a warning in our logs which says we have to upgrade to v3. It is part of `aws-actions/amazon-ecs-deploy-task-definition` and there is already a new version to fix this.

```
Run aws-actions/amazon-ecs-deploy-task-definition@v1
(node:2265) NOTE: The AWS SDK for JavaScript (v2) will enter maintenance mode
on September 8, 2024 and reach end-of-support on September 8, 2025.
Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check blog post at https://a.co/cUPnyil
(Use `node --trace-warnings ...` to show where the warning was created)
```

Docs:
https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-javascript-v2/