### PR TITLE
fix(action): deregister preflight task-definition even if the container crashes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -156,7 +156,7 @@ runs:
       run: aws ecs deregister-task-definition --task-definition "$TASK_DEFINITION_LOCAL"
 
     - name: Deregister preflight task definition
-      if: ${{ always() && steps.deploy-preflight-task-definition-and-run-task.outcome == 'success' && env.TASK_DEFINITION_PREFLIGHT != '' }}
+      if: ${{ always() && env.TASK_DEFINITION_PREFLIGHT != '' }}
       shell: bash
       run: aws ecs deregister-task-definition --task-definition "$TASK_DEFINITION_PREFLIGHT"
 


### PR DESCRIPTION
We identified issues if the preflight container crashes for instance of failing migrations. In this case the container will exit with exit code 1 and the task-definition will not be deregistered, which will block further deployments without manual intervention.

In my opinion we can delete the condition for successful preflight containers.

@windwinkel Thanks for pointing to the failed pipeline, this should fix the root cause.