### PR TITLE
fix(action): fix default value for allow_feature_branch_deployment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,12 +15,10 @@ inputs:
     required: true
   desired_count:
     description: Number of tasks running in ECS service
-    required: false
-    default: 2
+    required: true
   allow_feature_branch_deployment:
     description: Allow deployment from feature branch
-    required: false
-
+    required: true
   aws_access_key_id:
     description: AWS access key
     required: true

--- a/actions_helper/main.py
+++ b/actions_helper/main.py
@@ -25,12 +25,12 @@ def cli():
     short_help="Deploy production image to AWS ECS",
 )
 @click.option("--environment", type=click.Choice(Environment))
-@click.option("--allow-feature-branch-deployment", type=bool, default=False)
+@click.option("--allow-feature-branch-deployment", type=bool)
 @click.option("--ecr-repository", envvar="ECR_REPOSITORY", type=str)
 @click.option("--deployment-tag", envvar="DEPLOYMENT_TAG", type=str)
 @click.option("--image-tag", envvar="IMAGE_TAG", type=str)
 @click.option("--run-preflight", envvar="RUN_PREFLIGHT", type=bool)
-@click.option("--desired-count", default=2, type=int)
+@click.option("--desired-count", type=int)
 @click.option("--aws-region", envvar="AWS_DEFAULT_REGION", type=str)
 def cmd_ecs_deploy(
     environment: Environment,


### PR DESCRIPTION
Deploying softfair-proxy failed with error  `Error: Invalid value for '--allow-feature-branch-deployment': '' is not a valid boolean.`, see pipeline https://github.com/moneymeets/softfair-proxy/actions/runs/11974446052/job/33386112313.

It turns out that setting the default value for the click command does not work.
In `deploy.yaml` the input `allow_feature_branch_deployment` is not required.
When it is used in in call `poetry run actions_helper ecs-deploy` the value for `--allow-feature-branch-deployment` is an empty string. So the empty string is passed to the click function and the default value defined by `@click.option("--allow-feature-branch-deployment", type=bool, default=False)` is never in charge since empty string is passed.

The solution is to set a default value of `false` for `allow_feature_branch_deployment` in the `action.yml` the same way as it is done already for `desired_count`.

To avoid confusion @mm-matthias and I suggest to remove default values from `@click.option`s since they are never relevant anyways.